### PR TITLE
Create custom connect sequence and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 node_modules
+.cpcache/
+.nrepl-port
+**/.cache
+resources/public/js

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "calva.replConnectSequences": [
+    {
+      "name": "My local build",
+      "projectType": "deps.edn",
+      "cljsType": {
+        "dependsOn": "Figwheel Main",
+        "connectCode": "(start-cljs-repl)",
+        "isConnectedRegExp": "To quit, type: :cljs/quit",
+        "buildsRequired": false,
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@
    * Close the alert displayed
 1. Wait for the Calva output/repl window to display `; Connected session: cljs`
 1. Load `src/main/repro/ui/core.cljs` (open it and use the command **Calva: Load file and dependencies**) 
-
-
-... from here I want to open portal.cljs, eval the file and have Portal pop up.
-
-It requires some fiddling with “Toggle the REPL connection” for both output.calva-repl and my portal.cljs. And I have not found a sequence that is reliable yet.
+1. Also load `dev/tooling/portal.cljs`, and confirm that portal opens in a web browser window.
+1. Then evaluate the two forms in the rich comment block at the bottom of the file:
+    ```clojure
+    (comment
+      (open-portal)
+      (tap> "Tap, tap! Who's there?"))
+   ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Getting started with Calva
 
-1. Start a Clojure REPL: `make repl` 
-2. Connect to that via the "Connect to a Running REPL Server in the Project" command in VS Code. Choose "Generic" as the connection type. And copy & paste the port from where you did `make repl`
-3. Start a ClojureScript REPL: In `dev/user.clj`, evaluate `(start-cljs-repl)`
-4. Open a browser at http://localhost:9010 when it is done and says so
-5. When it is connected, it will have a `clj꞉cljs.user꞉>` prompt.
+1. Start a Clojure REPL: `make repl` (a VS Code integrated terminal works great for this.)
+1. Wait for the message `nREPL server started on port ...
+1. Connect the REPL via the "Connect to a Running REPL Server in the Project" command in VS Code.
+   * Choose "My local build" as the connection type
+   * Press enter at the next prompt which is prefilled with `localhost:<some-port>
+1. Wait for the app to compile and open in your browser (opens on http://localhost:9010)
+   * Close the alert displayed
+1. Wait for the Calva output/repl window to display `; Connected session: cljs`
+1. Load `src/main/repro/ui/core.cljs` (open it and use the command **Calva: Load file and dependencies**) 
+
 
 ... from here I want to open portal.cljs, eval the file and have Portal pop up.
 

--- a/dev/tooling/portal.cljs
+++ b/dev/tooling/portal.cljs
@@ -5,7 +5,10 @@
 (defn open-portal
   []
   (def p (p/open))
+  #_ (def p (p/open {:launcher :vs-code}))
   (add-tap #'p/submit)
   (tap> {::open-portal "Hello! Portal has been opened."}))
 
-#_ (open-portal)
+(comment
+  (open-portal))
+  

--- a/dev/tooling/portal.cljs
+++ b/dev/tooling/portal.cljs
@@ -4,11 +4,12 @@
 
 (defn open-portal
   []
-  (def p (p/open))
-  #_ (def p (p/open {:launcher :vs-code}))
-  (add-tap #'p/submit)
-  (tap> {::open-portal "Hello! Portal has been opened."}))
+  (let [ui (p/open)]
+    (add-tap #'p/submit)
+    (tap> {::open-portal "Hello! Portal has been opened."})
+    ui))
 
 (comment
-  (open-portal))
+  (open-portal)
+  (tap> "Tap, tap! Who's there?"))
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "calva-connect-to-figwheel-repro",
+    "name": "calva-clojurescript-usage",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/src/main/repro/ui/core.cljs
+++ b/src/main/repro/ui/core.cljs
@@ -2,3 +2,7 @@
 
 (defn ^export init []
   (js/alert "Here I am"))
+
+(comment
+  (println "Hello, I am here too")
+  (+ 1 2 3))


### PR DESCRIPTION
It's not perfect yet, but hopefully enough to get you to the next step experimenting with portal...

I don't quite understand why this merged thing doesn't work with the default Figwheel Main sequence, but I intend to find out. Let's update the issue on Calva, keeping it open.